### PR TITLE
Literal type

### DIFF
--- a/LiteralType.ts
+++ b/LiteralType.ts
@@ -1,0 +1,16 @@
+// String Literal type
+
+type CardinalDirection = 'North' | 'East' | 'South' | 'West';
+
+// you can't assign a new value out of CardinalDirection values 'North' |         'East' |  'South' | 'West'
+
+// let direction:CardinalDirection = 'omar' // Wrong
+
+let direction: CardinalDirection = 'East'; // Right
+
+// Number Literal type
+
+type OneToFive = 1 | 2 | 3 | 4 | 5;
+
+// Boolean Literal type
+type Bools = true | false;

--- a/ReadME.md
+++ b/ReadME.md
@@ -116,6 +116,9 @@ Each property in an object type must have a type that represent it.
   It creates a new name for a type.
   it doesn't actually create a new type - it creates a new name to refer to the type.
 
+- Literal Types:
+  Literal types in TypeScript allow for narrowing down the type to the exact value. You can communicate in the type system that the value has to be exactly this string not a string or one of those particular numbers and not just any number. Until TypeScript 4.1, we had three literal types: strings, numbers, and booleans. TypeScript 4.1 introduced the fourth literal type: template literal.
+
 #### The benifits of types inside typeScript :
 
 - Catch the error before Runtime the code.
@@ -128,3 +131,4 @@ Each property in an object type must have a type that represent it.
 ---
 
 [Link : Scaler topics](https://www.scaler.com/topics/what-is-typescript/)
+[Link : Literal Types](https://michalzalecki.com/typescript-template-literal-types/)


### PR DESCRIPTION
Literal types in TypeScript allow for narrowing down the type to the exact value. You can communicate in the type system that the value has to be exactly this string not a string or one of those particular numbers and not just any number. we had three literal types: strings, numbers, and booleans. 